### PR TITLE
Update media form ID for alter hook.

### DIFF
--- a/linkit_media_creation.module
+++ b/linkit_media_creation.module
@@ -64,7 +64,7 @@ function linkit_media_creation_form_editor_link_dialog_alter(&$form, FormStateIn
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function linkit_media_creation_form_media_document_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function linkit_media_creation_form_media_file_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (\Drupal::routeMatch()->getRouteName() == 'linkit_media_creation.dialogue') {
     $form['actions']['submit']['#ajax'] = [
       'callback' => 'linkit_media_creation_ajax_callback',


### PR DESCRIPTION
Looks like (perhaps when media was moved into core) the form ID for media entity edit form changed from "media_document_form" to "media_file_form". Since the wrong form ID is used, this module's ajax call back never gets registered on the media form. This PR is to update the alter hook function name.

Note: this is based off a vanilla 8.7.1 site. 

![linkit_media_creation_media_form_id](https://user-images.githubusercontent.com/12531176/61315822-9ca98380-a7cd-11e9-90cf-75bf872adc76.png)
