### PR TITLE
Dynamically set the list of bundles on the media creation dialog.

### DIFF
--- a/src/Form/LinkitMediaCreationDialogueForm.php
+++ b/src/Form/LinkitMediaCreationDialogueForm.php
@@ -4,6 +4,7 @@ namespace Drupal\linkit_media_creation\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Utility\UrlHelper;
 
 /**
  * LinkitMediaCreationDialogueForm.
@@ -29,7 +30,23 @@ class LinkitMediaCreationDialogueForm extends FormBase {
    */
   public function __construct() {
     $this->inputId = '123';
-    $this->bundles = ['image'];
+
+    $current_uri = \Drupal::requestStack()->getCurrentRequest()->getRequestUri();
+    $allowedBundles = explode(',', UrlHelper::parse($current_uri)['query']['bundles']);
+    $allowedBundles = array_map(function ($bundleLabel) {
+      return trim($bundleLabel);
+    }, $allowedBundles);
+
+    $this->bundles = [];
+    $allBundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
+
+    foreach ($allBundles as $bundleName => $bundle) {
+      $this->bundles[$bundleName] = $bundle['label'];
+    }
+
+    $this->bundles = array_filter($this->bundles, function ($bundleLabel, $bundleName) use ($allowedBundles) {
+      return in_array($bundleName, $allowedBundles);
+    }, ARRAY_FILTER_USE_BOTH);
   }
 
   /**


### PR DESCRIPTION
Currently, if there is more than one allowed bundle for the linkit matcher, [then a fixed list of image will be used](https://github.com/zweishar/Linkit-Media-Creation/blob/master/src/Form/LinkitMediaCreationDialogueForm.php#L32). Note: this is based off a vanilla 8.7.1 site.

![linkit_media_creation_hardcoded_list](https://user-images.githubusercontent.com/12531176/61316068-2ce7c880-a7ce-11e9-81ec-ba2403fe6f51.png)


This PR instead sets the list of bundles based on the config passed via the query string.
![linkit_media_creation_matcher_config_form](https://user-images.githubusercontent.com/12531176/61316287-abdd0100-a7ce-11e9-9569-085eb8be3aa3.png)

![linkit_media_creation_creaet_dialog_uri](https://user-images.githubusercontent.com/12531176/61316282-a8e21080-a7ce-11e9-9e62-cc921be6f5d0.png)
